### PR TITLE
feat: GA4 analytics + giscus comments

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,7 +22,7 @@ timezone: America/Los_Angeles
 analytics:
   provider: "google-gtag"
   google:
-    tracking_id: "G-XXXXXXXXXX"   # TODO: replace with GA4 Measurement ID before merge
+    tracking_id: "G-QHFHFCSVFE"
     anonymize_ip: false
 # google seo
 google_site_verification: cVblbcvaADqAyPz4PghXPiAodyz33PG9GITL7OEzJss

--- a/_config.yml
+++ b/_config.yml
@@ -50,9 +50,9 @@ repository: "kikin81/velazquez.github.io"
 comments:
   provider: "giscus"
   giscus:
-    repo_id: "REPLACE_ME"          # TODO: from giscus.app before merge
+    repo_id: "MDEwOlJlcG9zaXRvcnkxMDQ1MDM0MTg="
     category_name: "Comments"
-    category_id: "REPLACE_ME"      # TODO: from giscus.app before merge
+    category_id: "DIC_kwDOBjqYes4C-i3s"
     discussion_term: "pathname"
     reactions_enabled: "1"
     theme: "dark"                  # matches minimal_mistakes_skin: dark

--- a/_config.yml
+++ b/_config.yml
@@ -18,11 +18,11 @@ paginate: 5 # amount of posts to show
 paginate_path: /page:num/
 timezone: America/Los_Angeles
 
-# Analytics
+# Analytics (GA4 via gtag.js)
 analytics:
-  provider: google
+  provider: "google-gtag"
   google:
-    tracking_id: UA-41149470-1
+    tracking_id: "G-XXXXXXXXXX"   # TODO: replace with GA4 Measurement ID before merge
     anonymize_ip: false
 # google seo
 google_site_verification: cVblbcvaADqAyPz4PghXPiAodyz33PG9GITL7OEzJss
@@ -45,10 +45,17 @@ social:
     - "https://instagram.com/kikin81"
     - "https://www.linkedin.com/in/fsvelazquez"
 
+# GitHub repo backing giscus comments (Discussions)
+repository: "kikin81/velazquez.github.io"
 comments:
-  provider: disqus
-  disqus:
-    shortname: franciscovelazquez-com
+  provider: "giscus"
+  giscus:
+    repo_id: "REPLACE_ME"          # TODO: from giscus.app before merge
+    category_name: "Comments"
+    category_id: "REPLACE_ME"      # TODO: from giscus.app before merge
+    discussion_term: "pathname"
+    reactions_enabled: "1"
+    theme: "dark"                  # matches minimal_mistakes_skin: dark
 
 include:
   - _pages


### PR DESCRIPTION
## Summary
Modernizes the two stale integrations identified during the research pass. Builds on the Jekyll 4.x / GitHub Actions pipeline migration already on `main`.

- **Analytics:** `google` (Universal Analytics `UA-41149470-1`, dead since July 2023) → **`google-gtag` (GA4)**
- **Comments:** `disqus` → **giscus** (GitHub Discussions; Discussions already enabled on the repo)
- Adds the top-level `repository` key required by giscus

## ⚠️ Draft — IDs are placeholders
This PR must not be merged until the real IDs are filled in:
- [ ] GA4 Measurement ID → replace `G-XXXXXXXXXX` (`analytics.google.tracking_id`)
- [ ] giscus `repo_id` → replace `REPLACE_ME` (from giscus.app)
- [ ] giscus `category_id` → replace `REPLACE_ME` (from giscus.app)
- [ ] Install the giscus app on this repo: https://github.com/apps/giscus

## Notes
- minimal-mistakes only renders analytics + comments when `JEKYLL_ENV=production` (the workflow sets this).
- Old Disqus threads are **not** migrated; giscus starts fresh.
- Search is unchanged (theme's built-in lunr).

🤖 Generated with [Claude Code](https://claude.com/claude-code)