### PR TITLE
chore(ci): bump GitHub Actions to Node 24 majors

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,20 +22,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.4"
           bundler-cache: true
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
       - name: Build site
         run: bundle exec jekyll build
         env:
           JEKYLL_ENV: production
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
 
   deploy:
     needs: build
@@ -48,4 +48,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary
Bumps the Pages workflow actions to their latest majors (Node 24 runtime), clearing the Node 20 deprecation warning before GitHub forces Node 24 on **2026-06-16**. No Renovate on this repo, so pinned to **major tags** — patches/minors land automatically.

| Action | Before | After |
|---|---|---|
| actions/checkout | v4 | v6 |
| actions/configure-pages | v5 | v6 |
| actions/upload-pages-artifact | v3 | v5 |
| actions/deploy-pages | v4 | v5 |

`ruby/setup-ruby@v1` is a floating major (already current) and wasn't in the deprecation list — left as-is. `upload-pages-artifact@v5` + `deploy-pages@v5` are the matched current pair.

## Verification
The PR build check exercises checkout/configure-pages/upload on the new versions. The deploy step (deploy-pages@v5) runs on merge to `main`; previous deployment serves until it succeeds (zero downtime).

🤖 Generated with [Claude Code](https://claude.com/claude-code)